### PR TITLE
Add Codex prompt templates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,7 @@ Key expectations for this repository:
 - Prefer pure functions; isolate IO to scripts/ and bin/.
 - Maintain test coverage ≥ 70% (see `jest.config.js`).
 - Offer fixes that update docs or scripts when behavior changes.
+- Prompt templates live in `templates/codex/prompts/` for quick session kickoffs.
 
 Assistant behavior:
 - Propose changes that align with loaded rules.

--- a/templates/codex/prompts/add-service-with-di.txt
+++ b/templates/codex/prompts/add-service-with-di.txt
@@ -1,0 +1,1 @@
+Add the {Service} service using constructor-based dependency injection, wire it into existing CLI handlers, and provide focused unit tests for the new behavior.

--- a/templates/codex/prompts/harden-tests.txt
+++ b/templates/codex/prompts/harden-tests.txt
@@ -1,0 +1,1 @@
+Harden the {Area} test suite by adding regression cases for recent bugs, using fixtures to cover edge inputs, and keeping coverage thresholds green.

--- a/templates/codex/prompts/implement-repo-with-tests.txt
+++ b/templates/codex/prompts/implement-repo-with-tests.txt
@@ -1,0 +1,1 @@
+Implement the {Feature} repository with dependency-injected storage and add Jest tests covering create/read/update/delete paths.

--- a/templates/codex/prompts/refactor-for-di.txt
+++ b/templates/codex/prompts/refactor-for-di.txt
@@ -1,0 +1,1 @@
+Refactor {Module} to accept dependencies through parameters, remove direct require() side effects, and update tests to use injectable fakes.

--- a/templates/codex/prompts/sync-docs.txt
+++ b/templates/codex/prompts/sync-docs.txt
@@ -1,0 +1,1 @@
+Sync the docs for {Feature} with the implementation by updating README sections, usage examples, and changelog entries as needed.


### PR DESCRIPTION
## Summary
- add prompt templates for common Codex workflows
- reference the new prompt directory from the Codex guide

## Testing
- npm test

fixes #3  
------
https://chatgpt.com/codex/tasks/task_e_690bd58e78c0832f94ff089eda5f811d